### PR TITLE
Fix path cleaner

### DIFF
--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -4,7 +4,7 @@ import { getLocalizedPath } from '@/i18n/path'
 
 // Removes leading and trailing slashes from a path
 export function cleanPath(path: string) {
-  return path.replace(/^\/|\/$/g, '')
+  return path.replace(/^\/+|\/+$/g, '')
 }
 
 // Checks if the current path is the home/post/tag/about page


### PR DESCRIPTION
## Summary
- prevent leftover slashes in `cleanPath`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot write file because it would overwrite input file)*
- `npm run lint` *(fails: Cannot find package '@antfu/eslint-config')*

------
https://chatgpt.com/codex/tasks/task_e_683fb57080708323b0a58e55d3689a0a